### PR TITLE
Add unit tests for webrtc.js

### DIFF
--- a/test/_webrtc-mocks.js
+++ b/test/_webrtc-mocks.js
@@ -1,6 +1,5 @@
 // RTC classes mocks
 export class RTCPeerConnection {
-
   constructor(options, optional) {
     this.options = options;
     this.optional = optional;
@@ -17,11 +16,11 @@ export class RTCPeerConnection {
   }
 
   async createOffer(options) {
-    return Promise.resolve({type: "offer", sdp: "testOfferSdp"});
+    return Promise.resolve({ type: 'offer', sdp: 'testOfferSdp' });
   }
 
   async createAnswer(options) {
-    return Promise.resolve({type: "answer", sdp: "testAnswerSdp"});
+    return Promise.resolve({ type: 'answer', sdp: 'testAnswerSdp' });
   }
 
   async setLocalDescription(sessionDescription) {

--- a/test/_webrtc-mocks.js
+++ b/test/_webrtc-mocks.js
@@ -1,0 +1,67 @@
+// RTC classes mocks
+export class RTCPeerConnectionMock {
+  constructor(options, optional) {
+    this.constructorSpy.apply(this, arguments);
+    this.localDescription = null;
+    this.remoteDescription = null;
+    this.iceCandidates = [];
+    this.sentMessages = [];
+  }
+
+  constructorSpy() {
+  }
+
+  createDataChannel(label, options) {
+    return {};
+  }
+
+  async createOffer(options) {
+    return Promise.resolve({type: "offer", sdp: "testOfferSdp"});
+  }
+
+  async createAnswer(options) {
+    return Promise.resolve({type: "answer", sdp: "testAnswerSdp"});
+  }
+
+  async setLocalDescription(sessionDescription) {
+    this.localDescription = sessionDescription;
+    return Promise.resolve();
+  }
+
+  async setRemoteDescription(sessionDescription) {
+    this.remoteDescription = sessionDescription;
+    return Promise.resolve();
+  }
+
+  async addIceCandidate(iceCandidate) {
+    this.iceCandidates.push(iceCandidate);
+    return Promise.resolve();
+  }
+
+}
+
+Object.defineProperty(RTCPeerConnectionMock.prototype, 'onicecandidate', {
+  get() {},
+  set(newValue) {},
+  enumerable: true,
+  configurable: true,
+});
+
+Object.defineProperty(RTCPeerConnectionMock.prototype, 'ondatachannel', {
+  get() {},
+  set(newValue) {},
+  enumerable: true,
+  configurable: true,
+});
+
+export class RTCSessionDescriptionMock {
+  constructor(sessionDescription) {
+    Object.assign(this, sessionDescription);
+  }
+}
+
+export class RTCIceCandidateMock {
+  constructor(iceCandidate) {
+    Object.assign(this, iceCandidate);
+  }
+}

--- a/test/_webrtc-mocks.js
+++ b/test/_webrtc-mocks.js
@@ -1,14 +1,15 @@
 // RTC classes mocks
-export class RTCPeerConnectionMock {
+export class RTCPeerConnection {
+
   constructor(options, optional) {
-    this.constructorSpy.apply(this, arguments);
+    this.options = options;
+    this.optional = optional;
     this.localDescription = null;
     this.remoteDescription = null;
     this.iceCandidates = [];
     this.sentMessages = [];
-  }
-
-  constructorSpy() {
+    this.ondatachannelListener = null;
+    this.onicecandidateListener = null;
   }
 
   createDataChannel(label, options) {
@@ -38,29 +39,30 @@ export class RTCPeerConnectionMock {
     return Promise.resolve();
   }
 
+  get onicecandidate() {
+    return this.onicecandidateListener;
+  }
+
+  set onicecandidate(cb) {
+    this.onicecandidateListener = cb;
+  }
+
+  get ondatachannel() {
+    return this.ondatachannelListener;
+  }
+
+  set ondatachannel(cb) {
+    this.ondatachannelListener = cb;
+  }
 }
 
-Object.defineProperty(RTCPeerConnectionMock.prototype, 'onicecandidate', {
-  get() {},
-  set(newValue) {},
-  enumerable: true,
-  configurable: true,
-});
-
-Object.defineProperty(RTCPeerConnectionMock.prototype, 'ondatachannel', {
-  get() {},
-  set(newValue) {},
-  enumerable: true,
-  configurable: true,
-});
-
-export class RTCSessionDescriptionMock {
+export class RTCSessionDescription {
   constructor(sessionDescription) {
     Object.assign(this, sessionDescription);
   }
 }
 
-export class RTCIceCandidateMock {
+export class RTCIceCandidate {
   constructor(iceCandidate) {
     Object.assign(this, iceCandidate);
   }

--- a/test/webrtc.test.js
+++ b/test/webrtc.test.js
@@ -22,7 +22,7 @@ global.RTCIceCandidate = RTCIceCandidate;
 
 // Socket mock.
 class SocketMock {
-  send(type, data) { }
+  send(type, data) {}
 }
 
 describe('WebRTC', () => {
@@ -55,23 +55,28 @@ describe('WebRTC', () => {
   });
 
   test('receiveNewPeer() should initiate new rtc data channel', async () => {
-    const
-      instanceId = 'testId',
+    const instanceId = 'testId',
       scopeId = 'testScopeId',
       peerInstanceId = 'peerInstanceId',
-      pcOnIceCandidateMock = jest.spyOn(RTCPeerConnection.prototype, 'onicecandidate', 'set');
+      pcOnIceCandidateMock = jest.spyOn(
+        RTCPeerConnection.prototype,
+        'onicecandidate',
+        'set'
+      );
 
     rtc.start(instanceId, scopeId);
-    rtc.receiveNewPeer({instanceId: peerInstanceId});
+    rtc.receiveNewPeer({ instanceId: peerInstanceId });
     await new Promise(done => setImmediate(done));
 
     expect(rtc.peers).toHaveProperty(peerInstanceId);
-    expect(rtc.peers[peerInstanceId]).toHaveProperty("connection");
-    expect(rtc.peers[peerInstanceId]["connection"]).toBeInstanceOf(RTCPeerConnection);
-    expect(rtc.peers[peerInstanceId]).toHaveProperty("channel");
+    expect(rtc.peers[peerInstanceId]).toHaveProperty('connection');
+    expect(rtc.peers[peerInstanceId]['connection']).toBeInstanceOf(
+      RTCPeerConnection
+    );
+    expect(rtc.peers[peerInstanceId]).toHaveProperty('channel');
 
     // Check channel events are set.
-    const channel = rtc.peers[peerInstanceId]["channel"];
+    const channel = rtc.peers[peerInstanceId]['channel'];
     expect(channel.onopen).toBeInstanceOf(Function);
     expect(channel.onclose).toBeInstanceOf(Function);
     expect(channel.onmessage).toBeInstanceOf(Function);
@@ -79,17 +84,17 @@ describe('WebRTC', () => {
 
     // Check events are logged.
     logSpy.mockReset();
-    channel.onopen("onopen");
-    channel.onclose("onclose");
-    channel.onmessage("onmessage");
-    channel.onerror("onerror");
+    channel.onopen('onopen');
+    channel.onclose('onclose');
+    channel.onmessage('onmessage');
+    channel.onerror('onerror');
     expect(logSpy).toHaveBeenCalledTimes(4);
-    expect(logSpy.mock.calls[0][1]).toBe("onopen");
-    expect(logSpy.mock.calls[1][1]).toBe("onclose");
-    expect(logSpy.mock.calls[2][1]).toBe("onmessage");
-    expect(logSpy.mock.calls[3][1]).toBe("onerror");
+    expect(logSpy.mock.calls[0][1]).toBe('onopen');
+    expect(logSpy.mock.calls[1][1]).toBe('onclose');
+    expect(logSpy.mock.calls[2][1]).toBe('onmessage');
+    expect(logSpy.mock.calls[3][1]).toBe('onerror');
 
-    const pc = rtc.peers[peerInstanceId]["connection"];
+    const pc = rtc.peers[peerInstanceId]['connection'];
     expect(pc.options).toStrictEqual(WEBRTC_PEER_CONFIG);
     expect(pc.optional).toStrictEqual(WEBRTC_PEER_OPTIONS);
 
@@ -98,8 +103,12 @@ describe('WebRTC', () => {
     expect(onIceCandidate).toBeInstanceOf(Function);
 
     // Emulate onicecandidate event.
-    onIceCandidate.call(rtc.peers[peerInstanceId].connection, {candidate: "test-candidate1"});
-    onIceCandidate.call(rtc.peers[peerInstanceId].connection, {candidate: "test-candidate2"});
+    onIceCandidate.call(rtc.peers[peerInstanceId].connection, {
+      candidate: 'test-candidate1'
+    });
+    onIceCandidate.call(rtc.peers[peerInstanceId].connection, {
+      candidate: 'test-candidate2'
+    });
     onIceCandidate.call(rtc.peers[peerInstanceId].connection, {});
 
     expect(socketSendMock).toHaveBeenCalledTimes(4);
@@ -108,62 +117,71 @@ describe('WebRTC', () => {
       scopeId,
       to: peerInstanceId,
       type: 'offer',
-      data: {type: "offer", sdp: "testOfferSdp"}
+      data: { type: 'offer', sdp: 'testOfferSdp' }
     });
     expect(socketSendMock).nthCalledWith(3, WEBRTC_INTERNAL_MESSAGE, {
       instanceId,
       scopeId,
       to: peerInstanceId,
       type: 'candidate',
-      data: "test-candidate1"
+      data: 'test-candidate1'
     });
     expect(socketSendMock).nthCalledWith(4, WEBRTC_INTERNAL_MESSAGE, {
       instanceId,
       scopeId,
       to: peerInstanceId,
       type: 'candidate',
-      data: "test-candidate2"
+      data: 'test-candidate2'
     });
   });
 
   test('should handle "offer" internal message', async () => {
-    const
-      instanceId = 'testId',
+    const instanceId = 'testId',
       scopeId = 'testScopeId',
       peerInstanceId = 'peerInstanceId',
-      pcOnDataChannelMock = jest.spyOn(RTCPeerConnection.prototype, 'ondatachannel', 'set');
+      pcOnDataChannelMock = jest.spyOn(
+        RTCPeerConnection.prototype,
+        'ondatachannel',
+        'set'
+      );
 
     rtc.start(instanceId, scopeId);
     rtc.receiveInternalMessage({
-        instanceId: peerInstanceId,
-        scopeId,
-        to: instanceId,
-        type: 'offer',
-        data: {type: "offer", sdp: "testOfferSdp"}
+      instanceId: peerInstanceId,
+      scopeId,
+      to: instanceId,
+      type: 'offer',
+      data: { type: 'offer', sdp: 'testOfferSdp' }
     });
 
     await new Promise(done => setImmediate(done));
 
     expect(rtc.peers).toHaveProperty(peerInstanceId);
-    expect(rtc.peers[peerInstanceId]).toHaveProperty("connection");
-    expect(rtc.peers[peerInstanceId]["connection"]).toBeInstanceOf(RTCPeerConnection);
+    expect(rtc.peers[peerInstanceId]).toHaveProperty('connection');
+    expect(rtc.peers[peerInstanceId]['connection']).toBeInstanceOf(
+      RTCPeerConnection
+    );
 
-    const pc = rtc.peers[peerInstanceId]["connection"];
-    expect(pc.localDescription).toStrictEqual({type: "answer", sdp: "testAnswerSdp"});
-    expect(pc.remoteDescription).toStrictEqual(new RTCSessionDescription({type: "offer", sdp: "testOfferSdp"}));
+    const pc = rtc.peers[peerInstanceId]['connection'];
+    expect(pc.localDescription).toStrictEqual({
+      type: 'answer',
+      sdp: 'testAnswerSdp'
+    });
+    expect(pc.remoteDescription).toStrictEqual(
+      new RTCSessionDescription({ type: 'offer', sdp: 'testOfferSdp' })
+    );
 
     expect(pcOnDataChannelMock).toHaveBeenCalledTimes(1);
     const onDataChannel = pc.ondatachannel;
     expect(onDataChannel).toBeInstanceOf(Function);
     // Simulate ondatachannel.
-    onDataChannel.call(pc, {channel: {dummy: 1}});
+    onDataChannel.call(pc, { channel: { dummy: 1 } });
 
-    expect(rtc.peers[peerInstanceId]).toHaveProperty("channel");
+    expect(rtc.peers[peerInstanceId]).toHaveProperty('channel');
   });
 
   test('should handle "answer" internal message', async () => {
-    const
-      instanceId = 'testId',
+    const instanceId = 'testId',
       scopeId = 'testScopeId',
       peerInstanceId = 'peerInstanceId',
       pc = new RTCPeerConnection();
@@ -173,21 +191,22 @@ describe('WebRTC', () => {
       connection: pc
     };
     rtc.receiveInternalMessage({
-        instanceId: peerInstanceId,
-        scopeId,
-        to: instanceId,
-        type: 'answer',
-        data: {type: "answer", sdp: "testAnswerSdp"}
+      instanceId: peerInstanceId,
+      scopeId,
+      to: instanceId,
+      type: 'answer',
+      data: { type: 'answer', sdp: 'testAnswerSdp' }
     });
 
     await new Promise(done => setImmediate(done));
 
-    expect(pc.remoteDescription).toStrictEqual(new RTCSessionDescription({type: "answer", sdp: "testAnswerSdp"}));
+    expect(pc.remoteDescription).toStrictEqual(
+      new RTCSessionDescription({ type: 'answer', sdp: 'testAnswerSdp' })
+    );
   });
 
   test('should handle "candidate" internal message', async () => {
-    const
-      instanceId = 'testId',
+    const instanceId = 'testId',
       scopeId = 'testScopeId',
       peer1InstanceId = 'peer1InstanceId',
       peer2InstanceId = 'peer2InstanceId',
@@ -200,48 +219,65 @@ describe('WebRTC', () => {
       connection: pc
     };
     rtc.receiveInternalMessage({
-        instanceId: peer1InstanceId,
-        scopeId,
-        to: instanceId,
-        type: 'candidate',
-        data: {"dummy": 1}
+      instanceId: peer1InstanceId,
+      scopeId,
+      to: instanceId,
+      type: 'candidate',
+      data: { dummy: 1 }
     });
 
     await new Promise(done => setImmediate(done));
 
     expect(pc.iceCandidates).toHaveLength(1);
-    expect(pc.iceCandidates[0]).toStrictEqual(new RTCIceCandidate({"dummy": 1}))
+    expect(pc.iceCandidates[0]).toStrictEqual(
+      new RTCIceCandidate({ dummy: 1 })
+    );
 
     // Connection doesn't exists and must be created.
     rtc.receiveInternalMessage({
-        instanceId: peer2InstanceId,
-        scopeId,
-        to: instanceId,
-        type: 'candidate',
-        data: {"dummy": 2}
+      instanceId: peer2InstanceId,
+      scopeId,
+      to: instanceId,
+      type: 'candidate',
+      data: { dummy: 2 }
     });
 
     await new Promise(done => setImmediate(done));
 
     expect(rtc.peers).toHaveProperty(peer2InstanceId);
-    expect(rtc.peers[peer2InstanceId]).toHaveProperty("connection");
-    expect(rtc.peers[peer2InstanceId]["connection"]).toBeInstanceOf(RTCPeerConnection);
+    expect(rtc.peers[peer2InstanceId]).toHaveProperty('connection');
+    expect(rtc.peers[peer2InstanceId]['connection']).toBeInstanceOf(
+      RTCPeerConnection
+    );
 
-    const pc2 = rtc.peers[peer2InstanceId]["connection"];
+    const pc2 = rtc.peers[peer2InstanceId]['connection'];
     expect(pc2.iceCandidates).toHaveLength(1);
-    expect(pc2.iceCandidates[0]).toStrictEqual(new RTCIceCandidate({"dummy": 2}))
+    expect(pc2.iceCandidates[0]).toStrictEqual(
+      new RTCIceCandidate({ dummy: 2 })
+    );
   });
 
   test('sendMessage() should send messages to peers', async () => {
-    const
-      instanceId = 'testId',
+    const instanceId = 'testId',
       scopeId = 'testScopeId',
       peer1InstanceId = 'peer1InstanceId',
       peer2InstanceId = 'peer2InstanceId',
       channelSendMock = jest.fn(),
-      channel1 = {send: (data) => { channelSendMock(1, data) }},
-      channel2 = {send: (data) => { channelSendMock(2, data) }},
-      channelWithError = {send: () => { throw new Error() }};
+      channel1 = {
+        send: data => {
+          channelSendMock(1, data);
+        }
+      },
+      channel2 = {
+        send: data => {
+          channelSendMock(2, data);
+        }
+      },
+      channelWithError = {
+        send: () => {
+          throw new Error();
+        }
+      };
 
     rtc.start(instanceId, scopeId);
     rtc.peers = {};
@@ -249,37 +285,52 @@ describe('WebRTC', () => {
     rtc.peers[peer2InstanceId] = { channel: channel2 };
 
     // Broadcast.
-    rtc.sendMessage({"dummy": "hello"});
+    rtc.sendMessage({ dummy: 'hello' });
 
     expect(channelSendMock).toHaveBeenCalledTimes(2);
-    expect(channelSendMock).toHaveBeenNthCalledWith(1, 1, {"dummy": "hello"});
-    expect(channelSendMock).toHaveBeenNthCalledWith(2, 2, {"dummy": "hello"});
+    expect(channelSendMock).toHaveBeenNthCalledWith(1, 1, { dummy: 'hello' });
+    expect(channelSendMock).toHaveBeenNthCalledWith(2, 2, { dummy: 'hello' });
 
     // Single peer.
-    rtc.sendMessage({"dummy": "hello there"}, peer1InstanceId);
+    rtc.sendMessage({ dummy: 'hello there' }, peer1InstanceId);
     expect(channelSendMock).toHaveBeenCalledTimes(3);
-    expect(channelSendMock).toHaveBeenNthCalledWith(3, 1, {"dummy": "hello there"});
+    expect(channelSendMock).toHaveBeenNthCalledWith(3, 1, {
+      dummy: 'hello there'
+    });
 
     // Error handling.
     rtc.peers[peer1InstanceId] = { channel: channelWithError };
     expect(() => {
-      rtc.sendMessage({"dummy": "hello error"});
+      rtc.sendMessage({ dummy: 'hello error' });
     }).not.toThrow();
 
     expect(channelSendMock).toHaveBeenCalledTimes(4);
-    expect(channelSendMock).toHaveBeenNthCalledWith(4, 2, {"dummy": "hello error"});
+    expect(channelSendMock).toHaveBeenNthCalledWith(4, 2, {
+      dummy: 'hello error'
+    });
   });
 
   test('removePeer() should close channel', async () => {
-    const
-      instanceId = 'testId',
+    const instanceId = 'testId',
       scopeId = 'testScopeId',
       peer1InstanceId = 'peer1InstanceId',
       peer2InstanceId = 'peer2InstanceId',
       channelCloseMock = jest.fn(),
-      channel1 = {close: () => { channelCloseMock(1) }},
-      channel2 = {close: () => { channelCloseMock(2) }},
-      channelWithError = {send: () => { throw new Error() }};
+      channel1 = {
+        close: () => {
+          channelCloseMock(1);
+        }
+      },
+      channel2 = {
+        close: () => {
+          channelCloseMock(2);
+        }
+      },
+      channelWithError = {
+        send: () => {
+          throw new Error();
+        }
+      };
 
     rtc.start(instanceId, scopeId);
     rtc.peers = {};
@@ -294,7 +345,7 @@ describe('WebRTC', () => {
     expect(rtc.peers).toHaveProperty(peer2InstanceId);
 
     // Non-existing peer.
-    rtc.removePeer("invalid");
+    rtc.removePeer('invalid');
     expect(channelCloseMock).toHaveBeenCalledTimes(1);
     expect(rtc.peers).toHaveProperty(peer2InstanceId);
 
@@ -308,14 +359,21 @@ describe('WebRTC', () => {
   });
 
   test('stop() should close all channels and send peer left message', async () => {
-    const
-      instanceId = 'testId',
+    const instanceId = 'testId',
       scopeId = 'testScopeId',
       peer1InstanceId = 'peer1InstanceId',
       peer2InstanceId = 'peer2InstanceId',
       channelCloseMock = jest.fn(),
-      channel1 = {close: () => { channelCloseMock(1) }},
-      channel2 = {close: () => { channelCloseMock(2) }};
+      channel1 = {
+        close: () => {
+          channelCloseMock(1);
+        }
+      },
+      channel2 = {
+        close: () => {
+          channelCloseMock(2);
+        }
+      };
 
     rtc.start(instanceId, scopeId);
     rtc.peers = {};
@@ -337,10 +395,10 @@ describe('WebRTC', () => {
 
   test('error handler logs message', async () => {
     logSpy.mockReset();
-    const error = new Error("dummy");
-    rtc._handleError("test error message")(error);
+    const error = new Error('dummy');
+    rtc._handleError('test error message')(error);
     expect(logSpy).toHaveBeenCalledTimes(1);
-    expect(logSpy.mock.calls[0][0]).toBe("test error message");
+    expect(logSpy.mock.calls[0][0]).toBe('test error message');
     expect(logSpy.mock.calls[0][1]).toStrictEqual(error);
   });
 });

--- a/test/webrtc.test.js
+++ b/test/webrtc.test.js
@@ -1,33 +1,275 @@
-import { WebSocket } from 'mock-socket';
+import 'regenerator-runtime/runtime';
 
 import {
   WEBRTC_PEER_CONFIG,
   WEBRTC_PEER_OPTIONS,
-  Logger
+  WEBRTC_JOIN_ROOM,
+  Logger, WEBRTC_INTERNAL_MESSAGE, WEBRTC_PEER_LEFT
 } from 'syft-helpers.js';
-import Socket from '../src/sockets';
 import WebRTCClient from '../src/webrtc';
 
-global.WebSocket = WebSocket;
+// WebRTC mocks.
+import {
+  RTCPeerConnectionMock,
+  RTCSessionDescriptionMock,
+  RTCIceCandidateMock
+} from './_webrtc-mocks';
+global.RTCPeerConnection = RTCPeerConnectionMock;
+global.RTCSessionDescription = RTCSessionDescriptionMock;
+global.RTCIceCandidate = RTCIceCandidateMock;
 
-const url = 'ws://localhost:8080/';
+// Socket mock.
+class SocketMock {
+  send(type, data) { }
+}
 
 describe('WebRTC', () => {
-  test('THIS IS A DUMMY TEST', () => {
-    const logger = new Logger('syft.js', true);
+  const logger = new Logger('syft.js', true);
+  const socketMock = new SocketMock();
+  let rtc, socketSendMock;
 
-    const socket = new Socket({
-      url,
-      logger
-    });
-
-    const rtc = new WebRTCClient({
+  beforeEach(() => {
+    rtc = new WebRTCClient({
       peerConfig: WEBRTC_PEER_CONFIG,
       peerOptions: WEBRTC_PEER_OPTIONS,
       logger,
-      socket
+      socket: socketMock
+    });
+    socketSendMock = jest.spyOn(socketMock, 'send');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('start() sends message to join the scope', () => {
+    rtc.start('joinTestId', 'joinTestScope');
+    expect(socketSendMock).toBeCalledTimes(1);
+    expect(socketSendMock).lastCalledWith(WEBRTC_JOIN_ROOM, {
+      instanceId: 'joinTestId',
+      scopeId: 'joinTestScope'
+    });
+  });
+
+  test('receiveNewPeer() should initiate new rtc data channel', async () => {
+    const
+      instanceId = 'testId',
+      scopeId = 'testScopeId',
+      peerInstanceId = 'peerInstanceId',
+      rtcConstructorMock = jest.spyOn(RTCPeerConnection.prototype, 'constructorSpy'),
+      pcOnIceCandidateMock = jest.spyOn(RTCPeerConnection.prototype, 'onicecandidate', 'set');
+
+    rtc.start(instanceId, scopeId);
+    rtc.receiveNewPeer({instanceId: peerInstanceId});
+    await new Promise(done => setImmediate(done));
+
+    expect(rtcConstructorMock).toBeCalledWith(WEBRTC_PEER_CONFIG, WEBRTC_PEER_OPTIONS);
+    expect(rtc.peers).toHaveProperty(peerInstanceId);
+    expect(rtc.peers[peerInstanceId]).toHaveProperty("connection");
+    expect(rtc.peers[peerInstanceId]["connection"]).toBeInstanceOf(RTCPeerConnection);
+    expect(rtc.peers[peerInstanceId]).toHaveProperty("channel");
+
+    expect(pcOnIceCandidateMock).toHaveBeenCalledTimes(1);
+    const onIceCandidate = pcOnIceCandidateMock.mock.calls[0][0];
+    expect(onIceCandidate).toBeInstanceOf(Function);
+
+    // Emulate onicecandidate event.
+    onIceCandidate.call(rtc.peers[peerInstanceId].connection, {candidate: "test-candidate1"});
+    onIceCandidate.call(rtc.peers[peerInstanceId].connection, {candidate: "test-candidate2"});
+    onIceCandidate.call(rtc.peers[peerInstanceId].connection, {});
+
+    expect(socketSendMock).toHaveBeenCalledTimes(4);
+    expect(socketSendMock).nthCalledWith(2, WEBRTC_INTERNAL_MESSAGE, {
+      instanceId,
+      scopeId,
+      to: peerInstanceId,
+      type: 'offer',
+      data: {type: "offer", sdp: "testOfferSdp"}
+    });
+    expect(socketSendMock).nthCalledWith(3, WEBRTC_INTERNAL_MESSAGE, {
+      instanceId,
+      scopeId,
+      to: peerInstanceId,
+      type: 'candidate',
+      data: "test-candidate1"
+    });
+    expect(socketSendMock).nthCalledWith(4, WEBRTC_INTERNAL_MESSAGE, {
+      instanceId,
+      scopeId,
+      to: peerInstanceId,
+      type: 'candidate',
+      data: "test-candidate2"
+    });
+  });
+
+  test('should handle "offer" internal message', async () => {
+    const
+      instanceId = 'testId',
+      scopeId = 'testScopeId',
+      peerInstanceId = 'peerInstanceId',
+      rtcConstructorMock = jest.spyOn(RTCPeerConnection.prototype, 'constructorSpy'),
+      pcOnIceCandidateMock = jest.spyOn(RTCPeerConnection.prototype, 'onicecandidate', 'set'),
+      pcOnDataChannelMock = jest.spyOn(RTCPeerConnection.prototype, 'ondatachannel', 'set');
+
+    rtc.start(instanceId, scopeId);
+    rtc.receiveInternalMessage({
+        instanceId: peerInstanceId,
+        scopeId,
+        to: instanceId,
+        type: 'offer',
+        data: {type: "offer", sdp: "testOfferSdp"}
     });
 
-    expect(1).toBe(1);
+    await new Promise(done => setImmediate(done));
+
+    expect(rtcConstructorMock).toBeCalledWith(WEBRTC_PEER_CONFIG, WEBRTC_PEER_OPTIONS);
+    expect(rtc.peers).toHaveProperty(peerInstanceId);
+    expect(rtc.peers[peerInstanceId]).toHaveProperty("connection");
+    expect(rtc.peers[peerInstanceId]["connection"]).toBeInstanceOf(RTCPeerConnection);
+
+    const pc = rtc.peers[peerInstanceId]["connection"];
+    expect(pc.localDescription).toStrictEqual({type: "answer", sdp: "testAnswerSdp"});
+    expect(pc.remoteDescription).toStrictEqual(new RTCSessionDescription({type: "offer", sdp: "testOfferSdp"}));
+
+    expect(pcOnDataChannelMock).toHaveBeenCalledTimes(1);
+    const onDataChannel = pcOnDataChannelMock.mock.calls[0][0];
+    expect(onDataChannel).toBeInstanceOf(Function);
+    // Simulate ondatachannel.
+    onDataChannel.call(pc, {channel: {dummy: 1}});
+
+    expect(rtc.peers[peerInstanceId]).toHaveProperty("channel");
   });
+
+  test('should handle "answer" internal message', async () => {
+    const
+      instanceId = 'testId',
+      scopeId = 'testScopeId',
+      peerInstanceId = 'peerInstanceId',
+      pc = new RTCPeerConnection();
+
+    rtc.start(instanceId, scopeId);
+    rtc.peers[peerInstanceId] = {
+      connection: pc
+    };
+    rtc.receiveInternalMessage({
+        instanceId: peerInstanceId,
+        scopeId,
+        to: instanceId,
+        type: 'answer',
+        data: {type: "answer", sdp: "testAnswerSdp"}
+    });
+
+    await new Promise(done => setImmediate(done));
+
+    expect(pc.remoteDescription).toStrictEqual(new RTCSessionDescription({type: "answer", sdp: "testAnswerSdp"}));
+  });
+
+  test('should handle "candidate" internal message', async () => {
+    const
+      instanceId = 'testId',
+      scopeId = 'testScopeId',
+      peerInstanceId = 'peerInstanceId',
+      pc = new RTCPeerConnection();
+
+    rtc.start(instanceId, scopeId);
+    rtc.peers[peerInstanceId] = {
+      connection: pc
+    };
+    rtc.receiveInternalMessage({
+        instanceId: peerInstanceId,
+        scopeId,
+        to: instanceId,
+        type: 'candidate',
+        data: {"dummy": 1}
+    });
+
+    await new Promise(done => setImmediate(done));
+
+    expect(pc.iceCandidates).toHaveLength(1);
+    expect(pc.iceCandidates[0]).toStrictEqual(new RTCIceCandidate({"dummy": 1}))
+  });
+
+  test('sendMessage() should send messages to peers', async () => {
+    const
+      instanceId = 'testId',
+      scopeId = 'testScopeId',
+      peer1InstanceId = 'peer1InstanceId',
+      peer2InstanceId = 'peer2InstanceId',
+      channelSendMock = jest.fn(),
+      channel1 = {send: (data) => { channelSendMock(1, data) }},
+      channel2 = {send: (data) => { channelSendMock(2, data) }};
+
+    rtc.start(instanceId, scopeId);
+    rtc.peers = {};
+    rtc.peers[peer1InstanceId] = { channel: channel1 };
+    rtc.peers[peer2InstanceId] = { channel: channel2 };
+
+    // Broadcast.
+    rtc.sendMessage({"dummy": "hello"});
+
+    expect(channelSendMock).toHaveBeenCalledTimes(2);
+    expect(channelSendMock).toHaveBeenNthCalledWith(1, 1, {"dummy": "hello"});
+    expect(channelSendMock).toHaveBeenNthCalledWith(2, 2, {"dummy": "hello"});
+
+    // Single peer.
+    rtc.sendMessage({"dummy": "hello there"}, peer1InstanceId);
+    expect(channelSendMock).toHaveBeenNthCalledWith(3, 1, {"dummy": "hello there"});
+  });
+
+  test('removePeer() should close channel', async () => {
+    const
+      instanceId = 'testId',
+      scopeId = 'testScopeId',
+      peer1InstanceId = 'peer1InstanceId',
+      peer2InstanceId = 'peer2InstanceId',
+      channelCloseMock = jest.fn(),
+      channel1 = {close: () => { channelCloseMock(1) }},
+      channel2 = {close: () => { channelCloseMock(2) }};
+
+    rtc.start(instanceId, scopeId);
+    rtc.peers = {};
+    rtc.peers[peer1InstanceId] = { channel: channel1 };
+    rtc.peers[peer2InstanceId] = { channel: channel2 };
+
+    rtc.removePeer(peer1InstanceId);
+
+    expect(channelCloseMock).toHaveBeenCalledTimes(1);
+    expect(channelCloseMock).toHaveBeenNthCalledWith(1, 1);
+    expect(rtc.peers).not.toHaveProperty(peer1InstanceId);
+    expect(rtc.peers).toHaveProperty(peer2InstanceId);
+
+    // Non-existing peer.
+    rtc.removePeer("invalid");
+    expect(channelCloseMock).toHaveBeenCalledTimes(1);
+    expect(rtc.peers).toHaveProperty(peer2InstanceId);
+  });
+
+  test('stop() should close all channels and send peer left message', async () => {
+    const
+      instanceId = 'testId',
+      scopeId = 'testScopeId',
+      peer1InstanceId = 'peer1InstanceId',
+      peer2InstanceId = 'peer2InstanceId',
+      channelCloseMock = jest.fn(),
+      channel1 = {close: () => { channelCloseMock(1) }},
+      channel2 = {close: () => { channelCloseMock(2) }};
+
+    rtc.start(instanceId, scopeId);
+    rtc.peers = {};
+    rtc.peers[peer1InstanceId] = { channel: channel1 };
+    rtc.peers[peer2InstanceId] = { channel: channel2 };
+
+    rtc.stop();
+
+    expect(channelCloseMock).toHaveBeenCalledTimes(2);
+    expect(rtc.peers).not.toHaveProperty(peer1InstanceId);
+    expect(rtc.peers).not.toHaveProperty(peer2InstanceId);
+
+    expect(socketSendMock).toBeCalledTimes(2);
+    expect(socketSendMock).lastCalledWith(WEBRTC_PEER_LEFT, {
+      instanceId,
+      scopeId
+    });
+  });
+
 });


### PR DESCRIPTION
This for https://github.com/OpenMined/syft.js/issues/48

Some corner cases need to be covered, however, I've got concern that mocking browser's RTC might be wrong direction, as this doesn't actually test that RTC works. Tests are not being executed in browser(s).
E.g. I tried to run "with-grid" example to establish connection between Chrome and FF, and this didn't work. Maybe this should be covered by some separate integration test suite, though, not sure.