### PR TITLE
Fix specific case in string serde

### DIFF
--- a/src/serde.js
+++ b/src/serde.js
@@ -32,7 +32,7 @@ export const SIMPLIFY_REPLACERS = [
 export const DETAIL_REPLACERS = [
   [/\(/g, '['], // Convert all Python tuples into a Javascript Array
   [/\)/g, ']'],
-  [/b'/g, "'"], // Convert all undefined 'b' functions everywhere, remove them
+  [/b'(.*?)'/g, "'$1'"], // Convert all undefined 'b' functions everywhere, remove them
   [/'/g, '"'], // Convert all single quotes to double quotes so JSON can parse correctly
   [/None/g, null], // Convert all Nones to nulls
   [/False/g, false], // Convert all False to false

--- a/test/dummy/native.js
+++ b/test/dummy/native.js
@@ -28,8 +28,8 @@ export const nullStepSlice = new Slice(start, end);
 export const simplifiedSlice = `(${proto['slice']}, (${start}, ${end}, ${step}))`; // prettier-ignore
 
 // ----- STRING ----- //
-export const string = 'hello';
-export const simplifiedString = `(${proto['str']}, (b'hello',))`; // prettier-ignore
+export const string = 'bob';
+export const simplifiedString = `(${proto['str']}, (b'bob',))`; // prettier-ignore
 
 // ----- TUPLE ----- //
 export const tuple = new Tuple('apple', 'cherry', 'banana');


### PR DESCRIPTION
All `b'`'s are removed in `detail` function, but this might be part of actual string, e.g. `b'bob'` => `'bo'`