### PR TITLE
Update serde, fix npm install issue, fix with-node example

### DIFF
--- a/examples/with-grid/index.html
+++ b/examples/with-grid/index.html
@@ -39,7 +39,8 @@
 
     <title>syft.js Example</title>
 
-    <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@1.2.5/dist/tf.min.js"></script>
+    <!-- NOTE: TFJS version must match with one in package-lock.json -->
+    <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@1.3.2/dist/tf.min.js"></script>
     <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
   </head>
   <body>
@@ -71,7 +72,7 @@
       >.
     </p>
     <input type="text" id="grid-server" value="ws://localhost:3000" />
-    <input type="text" id="protocol" value="5259950754" />
+    <input type="text" id="protocol" value="50801316202" />
     <button id="connect">Connect to grid.js server</button>
     <div id="app">
       <button id="disconnect">Disconnect</button>

--- a/jest-globals.js
+++ b/jest-globals.js
@@ -1,7 +1,10 @@
-global.tf = {
-  tensor: (value, shape, type) => {
-    console.log('Created a tensor!', value, shape, type);
-  },
-  add: jest.fn(),
-  abs: jest.fn()
-};
+import * as tf from '@tensorflow/tfjs';
+const tensor = tf.tensor;
+jest.spyOn(tf, 'tensor').mockImplementation((values, shape, dtype) => {
+  let t = tensor(values, shape, dtype);
+  // override id to always return same value
+  Object.defineProperty(t, 'id', {
+    value: 42
+  });
+  return t;
+});

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "scripts": {
     "start": "rollup -cw",
     "build": "rollup -c",
-    "prepublish": "npm run build",
+    "prepare": "npm run build",
     "test": "jest --coverage",
     "test:watch": "jest --watch",
     "version": "auto-changelog -p && git add CHANGELOG.md",

--- a/src/_helpers.js
+++ b/src/_helpers.js
@@ -1,6 +1,7 @@
 import { TorchTensor } from './types/torch';
 import PointerTensor from './types/pointer-tensor';
 import { CANNOT_FIND_COMMAND } from './_errors';
+import * as tf from '@tensorflow/tfjs';
 
 export const pickTensors = tree => {
   const objects = {};

--- a/src/serde.js
+++ b/src/serde.js
@@ -88,7 +88,7 @@ export const detail = data => {
     [proto['torch.Size']]: d => new TorchSize(d),
     [proto['syft.messaging.plan.plan.Plan']]: d => new Plan(...d.map(i => parse(i))),
     [proto['syft.messaging.plan.state.State']]: d => new State(...d.map(i => parse(i))),
-    [proto['syft.messaging.plan.procedure.Procedure']]: d => new Procedure(d[0].map(i => parse(i)), ...d.slice(1).map(i => parse(i))),
+    [proto['syft.messaging.plan.procedure.Procedure']]: d => new Procedure(...d.map(i => parse(i))),
     [proto['syft.messaging.protocol.Protocol']]: d => new Protocol(...d.map(i => parse(i))),
     [proto['syft.generic.pointers.pointer_tensor.PointerTensor']]: d => new PointerTensor(...d.map(i => parse(i))),
     [proto['syft.messaging.message.Message']]: d => new Message(...d.map(i => parse(i))),

--- a/src/types/torch.js
+++ b/src/types/torch.js
@@ -1,4 +1,5 @@
 import { default as proto } from '../proto';
+import * as tf from '@tensorflow/tfjs';
 
 export class TorchTensor {
   constructor(id, bin, chain, gradChain, tags, description, serializer) {


### PR DESCRIPTION
Changes:
1. `package.json`: replaced `prepublish` with `prepare` because `prepublish` doesn't seem to work when installing package from git (e.g. in grid.js). This fixes the problem that installing syft.js from git installs empty package.
2. Procedure's serde is updated to align with the latest PySyft.
3. tfjs is imported so it's real, but for unit tests, tensor.id is mocked to pass tfjs tensor comparisons (because each tfjs tensor is unique & readonly).
4. with-grid example is updated to use same TF version as in syft.js's package.json and use ID from updated grid.js seed (PR: https://github.com/OpenMined/grid.js/pull/22).
