### PR TITLE
Initial protobuf implementation: Protocol, ObjectMessage, TorchTensor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9136,8 +9136,8 @@
       }
     },
     "syft-proto": {
-      "version": "git+https://github.com/OpenMined/syft-proto.git#0cae6d31b5277205a821a26e2492d632aeb0d311",
-      "from": "git+https://github.com/OpenMined/syft-proto.git#vvm/protocol-js-stubs",
+      "version": "git+https://github.com/OpenMined/syft-proto.git#eff3cf882c5f76ef26f465887ea3fa8452d3854a",
+      "from": "git+https://github.com/OpenMined/syft-proto.git",
       "requires": {
         "protobufjs": "~6.8.8"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1018,6 +1018,60 @@
         "@types/yargs": "^13.0.0"
       }
     },
+    "@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+    },
+    "@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+    },
+    "@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+    },
+    "@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+    },
+    "@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+    },
+    "@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+    },
+    "@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+    },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
@@ -1187,6 +1241,11 @@
         "@types/istanbul-lib-coverage": "*",
         "@types/istanbul-lib-report": "*"
       }
+    },
+    "@types/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q=="
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -6225,6 +6284,11 @@
         }
       }
     },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -7776,6 +7840,33 @@
         "sisteransi": "^1.0.3"
       }
     },
+    "protobufjs": {
+      "version": "6.8.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
+      "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.0",
+        "@types/node": "^10.1.0",
+        "long": "^4.0.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.17.13",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.13.tgz",
+          "integrity": "sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg=="
+        }
+      }
+    },
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -9045,8 +9136,11 @@
       }
     },
     "syft-proto": {
-      "version": "git+https://github.com/OpenMined/syft-proto.git#a98f68327549ba5154425a8724d58b4150eab23d",
-      "from": "git+https://github.com/OpenMined/syft-proto.git"
+      "version": "git+https://github.com/OpenMined/syft-proto.git#0cae6d31b5277205a821a26e2492d632aeb0d311",
+      "from": "git+https://github.com/OpenMined/syft-proto.git#vvm/protocol-js-stubs",
+      "requires": {
+        "protobufjs": "~6.8.8"
+      }
     },
     "symbol-observable": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@tensorflow/tfjs": "^1.5.1",
     "long": "^4.0.0",
-    "syft-proto": "git+https://github.com/OpenMined/syft-proto.git#vvm/protocol-js-stubs",
+    "syft-proto": "git+https://github.com/OpenMined/syft-proto.git",
     "tuple-w": "^1.1.1"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
   },
   "dependencies": {
     "@tensorflow/tfjs": "^1.5.1",
-    "syft-proto": "git+https://github.com/OpenMined/syft-proto.git",
+    "long": "^4.0.0",
+    "syft-proto": "git+https://github.com/OpenMined/syft-proto.git#vvm/protocol-js-stubs",
     "tuple-w": "^1.1.1"
   },
   "peerDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,10 @@ export { default as EventObserver } from './events';
 
 // Export Serde simplify and detail
 export { simplify, detail } from './serde';
+export * from './protobuf';
+export { default as Protocol } from './types/protocol';
+export * from './types/message';
+export { protobuf } from './proto';
 
 // Export as default AND as named
 export { default as Syft } from './syft';

--- a/src/proto.js
+++ b/src/proto.js
@@ -7,3 +7,4 @@ for (let type of Object.keys(proto_info.TYPES)) {
 }
 
 export default PROTO;
+export { protobuf } from 'syft-proto';

--- a/src/protobuf/index.js
+++ b/src/protobuf/index.js
@@ -1,0 +1,24 @@
+import { NO_DETAILER } from '../_errors';
+import { initMappings, PB_TO_UNBUFFERIZER } from './mapping';
+
+export const unbufferize = (worker, pbObj) => {
+  if (!PB_TO_UNBUFFERIZER) {
+    initMappings();
+  }
+  const pbType = pbObj.constructor;
+  const unbufferizer = PB_TO_UNBUFFERIZER[pbType];
+  if (typeof unbufferizer === 'undefined') {
+    throw new Error(NO_DETAILER(pbType));
+  }
+  return unbufferizer(worker, pbObj);
+};
+
+export const unserialize = (worker, bin, pbType) => {
+  const buff = Buffer.from(bin, 'base64');
+  const pbObj = pbType.decode(buff);
+  return unbufferize(worker, pbObj);
+};
+
+export const getPbId = field => {
+  return field[field.id];
+};

--- a/src/protobuf/mapping.js
+++ b/src/protobuf/mapping.js
@@ -1,0 +1,23 @@
+import { protobuf } from 'syft-proto';
+import Protocol from '../types/protocol';
+import { ObjectMessage } from '../types/message';
+import { TorchTensor } from '../types/torch';
+
+let PB_CLASS_MAP, PB_TO_UNBUFFERIZER;
+
+// because of cyclic dependencies between Protocol/etc modules and protobuf module
+// Protocol/etc classes are undefined at the moment when this module is imported
+export const initMappings = () => {
+  PB_CLASS_MAP = [
+    [Protocol, protobuf.syft_proto.messaging.v1.Protocol],
+    [ObjectMessage, protobuf.syft_proto.messaging.v1.ObjectMessage],
+    [TorchTensor, protobuf.syft_proto.types.torch.v1.TorchTensor]
+  ];
+
+  PB_TO_UNBUFFERIZER = PB_CLASS_MAP.reduce((map, item) => {
+    map[item[1]] = item[0].unbufferize;
+    return map;
+  }, {});
+};
+
+export { PB_CLASS_MAP, PB_TO_UNBUFFERIZER };

--- a/src/syft.js
+++ b/src/syft.js
@@ -14,6 +14,8 @@ import Logger from './logger';
 import Socket from './sockets';
 import WebRTCClient from './webrtc';
 import { detail } from './serde';
+import { unserialize } from './protobuf';
+import { protobuf } from './proto';
 import { pickTensors } from './_helpers';
 
 export default class Syft {
@@ -198,8 +200,24 @@ export default class Syft {
         this.participants = data.participants;
 
         // Save the protocol and plan assignment after having Serde detail them
-        const detailedProtocol = detail(data.protocol);
-        const detailedPlan = detail(data.plan);
+        let detailedProtocol;
+        let detailedPlan;
+        try {
+          detailedProtocol = detail(data.protocol);
+          detailedPlan = detail(data.plan);
+        } catch (e) {
+          // fallback to protobuf
+          detailedProtocol = unserialize(
+            null,
+            data.protocol,
+            protobuf.syft_proto.messaging.v1.Protocol
+          );
+          detailedPlan = unserialize(
+            null,
+            data.plan,
+            protobuf.syft_proto.messaging.v1.ObjectMessage
+          );
+        }
 
         this.protocol = detailedProtocol;
         this.plan = detailedPlan;

--- a/src/types/message.js
+++ b/src/types/message.js
@@ -1,4 +1,5 @@
 import { default as proto } from '../proto';
+import { unbufferize } from '../protobuf';
 import PointerTensor from './pointer-tensor';
 
 import { torchToTF } from '../_helpers';
@@ -119,6 +120,11 @@ export class ObjectMessage extends Message {
   serdeSimplify(f) {
     const TYPE = proto['syft.messaging.message.ObjectMessage'];
     return `(${TYPE}, (${f(this.contents)}))`; // prettier-ignore
+  }
+
+  static unbufferize(worker, pb) {
+    const tensor = unbufferize(worker, pb.tensor);
+    return new ObjectMessage(tensor);
   }
 }
 

--- a/src/types/protocol.js
+++ b/src/types/protocol.js
@@ -1,4 +1,5 @@
 import { default as proto } from '../proto';
+import { getPbId } from '../protobuf';
 
 export default class Protocol {
   constructor(id, tags, description, plans, workersResolved) {
@@ -13,5 +14,19 @@ export default class Protocol {
     const TYPE = proto['syft.messaging.protocol.Protocol'];
     const args = ['id', 'tags', 'description', 'plans', 'workersResolved']; // prettier-ignore
     return `(${TYPE}, (${args.map(i => f(this[i])).join()}))`; // prettier-ignore
+  }
+
+  static unbufferize(worker, pb) {
+    const planAssignments = [];
+    pb.plan_assignments.forEach(item => {
+      planAssignments.push([getPbId(item.worker_id), getPbId(item.plan_id)]);
+    });
+    return new Protocol(
+      getPbId(pb.id),
+      pb.tags,
+      pb.description,
+      planAssignments,
+      pb.workersResolved
+    );
   }
 }

--- a/test/dummy/native.js
+++ b/test/dummy/native.js
@@ -2,7 +2,10 @@ import { default as proto } from '../../src/proto';
 import { Dict, List, Range, Slice, Tuple } from '../../src/types/native';
 
 // ----- DICT ----- //
-export const dict = new Dict([[1, 'hello'], ['key2', 999]]);
+export const dict = new Dict([
+  [1, 'hello'],
+  ['key2', 999]
+]);
 export const simplifiedDict = `(${proto['dict']}, ((${proto['list']}, (${proto['str']}, (b'hello',))), ((${proto['str']}, (b'key2',)), 999)))`; // prettier-ignore
 
 // ----- LIST ----- //

--- a/test/protobuf.test.js
+++ b/test/protobuf.test.js
@@ -1,0 +1,44 @@
+import { unserialize, getPbId } from '../src/protobuf';
+import { protobuf } from '../src/proto';
+import { ObjectMessage } from '../src/types/message';
+import Protocol from '../src/types/protocol';
+import { fromNumber } from 'long';
+
+describe('Protobuf', () => {
+  test('can unserialize an ObjectMessage', () => {
+    const obj = unserialize(
+      null,
+      'CjcKBwi91JDfnQISKgoECgICAxIHZmxvYXQzMrIBGAAAgD8AAABAAABAQAAAgEAAAKBAMzPDQEAE',
+      protobuf.syft_proto.messaging.v1.ObjectMessage
+    );
+    expect(obj).toBeInstanceOf(ObjectMessage);
+  });
+
+  test('can unserialize a Protocol', () => {
+    const protocol = unserialize(
+      null,
+      'CgcIzuzNqtECKhQKBwi91JDfnQISCRIHd29ya2VyMQ==',
+      protobuf.syft_proto.messaging.v1.Protocol
+    );
+    expect(protocol).toBeInstanceOf(Protocol);
+  });
+
+  test('gets id from types.syft.Id', () => {
+    const protocolWithIntId = protobuf.syft_proto.messaging.v1.Protocol.fromObject(
+      {
+        id: {
+          id_int: 123
+        }
+      }
+    );
+    const protocolWithStrId = protobuf.syft_proto.messaging.v1.Protocol.fromObject(
+      {
+        id: {
+          id_str: '321'
+        }
+      }
+    );
+    expect(fromNumber(123).eq(getPbId(protocolWithIntId.id))).toBe(true);
+    expect(getPbId(protocolWithStrId.id)).toBe('321');
+  });
+});


### PR DESCRIPTION
This PR contains initial implementation of protobuf in syft.js as a PoC.
Following classes can be decoded from base64-encoded protobuf binary:
* Protocol
* ObjectMessage
* TorchTensor (w/o grad, chain)

Old serde is still present, protobuf is used when serde can't be decoded.

Module naming, exports, and code structure probably need more ❤️.
E.g. having "proto" and "protobuf" might be confusing.

NOTE: package.json is using non-master branch of syft-proto, so unit tests can pass; this needs to be changed before merge.