### PR TITLE
Make package installable from git

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,6 @@
 node_modules
 coverage
 examples
-src
 test
 tmp
 yarn.lock

--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "browser": "dist/index.js",
-  "files": [
-    "dist"
-  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/OpenMined/syft.js.git"
@@ -34,7 +31,7 @@
   "scripts": {
     "start": "rollup -cw",
     "build": "rollup -c",
-    "prepublishOnly": "npm run build",
+    "prepare": "npm run build",
     "test": "jest --coverage",
     "test:watch": "jest --watch",
     "version": "auto-changelog -p && git add CHANGELOG.md",


### PR DESCRIPTION
Currently it is required to build and publish syft.js to use it in other projects such as grid.js.
This change allows to install syft.js directly from git, for faster turnaround during development.