### PR TITLE
Update syft-proto to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1510,9 +1510,9 @@
       }
     },
     "@types/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
+      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -8022,9 +8022,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.13",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.13.tgz",
-          "integrity": "sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg=="
+          "version": "10.17.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.14.tgz",
+          "integrity": "sha512-G0UmX5uKEmW+ZAhmZ6PLTQ5eu/VPaT+d/tdLd5IFsKRPcbe6lPxocBtcYBFSaLaCW8O60AX90e91Nsp8lVHCNw=="
         }
       }
     },
@@ -9285,7 +9285,7 @@
       }
     },
     "syft-proto": {
-      "version": "git+https://github.com/OpenMined/syft-proto.git#eff3cf882c5f76ef26f465887ea3fa8452d3854a",
+      "version": "git+https://github.com/OpenMined/syft-proto.git#108abdce1d43fce46fe014ea340cfb69ec39f91f",
       "from": "git+https://github.com/OpenMined/syft-proto.git",
       "requires": {
         "protobufjs": "~6.8.8"


### PR DESCRIPTION
Just updates syft-proto to latest version in syft-proto repo.
This is needed to work on Plan's protobuf in both syft.js and grid.js (example) because grid.js consumes syft-proto via syft.js.