### PR TITLE
PyGrid integration

### DIFF
--- a/examples/with-grid/index.html
+++ b/examples/with-grid/index.html
@@ -35,6 +35,19 @@
       #participant-links li {
         padding: 5px 0px;
       }
+
+      form {
+        display: table;
+      }
+
+      form p {
+        display: table-row;
+      }
+
+      form label {
+        display: table-cell;
+        padding: 5px;
+      }
     </style>
 
     <title>syft.js Example</title>
@@ -72,10 +85,31 @@
         >)</i
       >.
     </p>
-    <input type="text" id="grid-server" value="ws://localhost:3000" />
+
+    <form action="#">
+      <p>
+        <label for="grid-server">Grid URL:</label>
+        <input type="text" id="grid-server" value="ws://localhost:5000" />
+      </p>
+
+      <p>
+        <label for="model-id">FL Model Name:</label>
+        <input type="text" id="model-id" value="mnist" />
+      </p>
+
+      <p>
+        <label for="model-id">FL Model Version:</label>
+        <input type="text" id="model-version" value="1.0.0" />
+      </p>
+
+      <p>
+        <button id="start">Start FL Worker</button>
+      </p>
+    </form>
+
+
     <!--    <input type="text" id="protocol" value="10000000013" />-->
     <!--    <button id="connect">Connect to grid.js server</button>-->
-    <button id="start">Start FL Worker</button>
 
     <div id="fl-training" style="display: none">
       <div style="display: table-row">

--- a/examples/with-grid/index.js
+++ b/examples/with-grid/index.js
@@ -53,12 +53,14 @@ connectButton.onclick = () => {
 
 startButton.onclick = () => {
   setFLUI();
-  startFL(gridServer.value, 'model-id');
+  const modelName = document.getElementById('model-id').value;
+  const modelVersion = document.getElementById('model-version').value;
+  startFL(gridServer.value, modelName, modelVersion);
 };
 
-const startFL = async (url, modelName) => {
+const startFL = async (url, modelName, modelVersion) => {
   const worker = new Syft({ url, verbose: true });
-  const job = await worker.newJob({ modelName });
+  const job = await worker.newJob({ modelName, modelVersion });
 
   job.start();
 
@@ -141,10 +143,7 @@ const startFL = async (url, modelName) => {
     // job.protocols['secure_aggregation'].execute();
 
     // Calc model diff.
-    const modelDiff = [];
-    for (let i = 0; i < modelParams.length; i++) {
-      modelDiff.push(model.params[i].sub(modelParams[i]));
-    }
+    const modelDiff = await model.createSerializedDiff(modelParams);
 
     // Report diff.
     await job.report(modelDiff);

--- a/src/grid-api-client.js
+++ b/src/grid-api-client.js
@@ -1,22 +1,53 @@
 import Logger from './logger';
 
+const HTTP_PATH_VERB = {
+  'federated/get-plan': 'GET',
+  'federated/get-model': 'GET',
+  'federated/cycle-request': 'POST'
+};
+
 export default class GridAPIClient {
   constructor({ url }) {
-    this.url = url;
-    this.logger = new Logger();
+    this.transport = url.match(/^ws/i) ? 'ws' : 'http';
+    if (this.transport === 'ws') {
+      this.wsUrl = url;
+      this.httpUrl = url.replace(/^ws(s)?/i, 'http$1');
+    } else {
+      this.httpUrl = url;
+      this.wsUrl = url.replace(/^http(s)?/i, 'ws$1');
+    }
+    this.ws = null;
+    this.logger = new Logger('grid', true);
+    this.responseTimeout = 10000;
   }
 
-  authenticate(authToken) {
+  async authenticate(authToken) {
     this.logger.log(`Authenticating with ${authToken}...`);
-    return Promise.resolve({
-      worker_id: '12345'
+
+    const response = await this._send('federated/authenticate', {
+      auth_token: authToken
     });
+
+    return response;
   }
 
   requestCycle(workerId, modelName, modelVersion, ping, download, upload) {
     this.logger.log(
       `[WID: ${workerId}] Requesting cycle for model ${modelName} v.${modelVersion} [${ping}, ${download}, ${upload}]...`
     );
+
+    const response = this._send('federated/cycle-request', {
+      worker_id: workerId,
+      model: modelName,
+      version: modelVersion,
+      ping: ping,
+      download: download,
+      upload: upload
+    });
+
+    return response;
+
+    /*
     return Promise.resolve({
       status: 'accepted',
       request_key: 'request_key',
@@ -31,23 +62,49 @@ export default class GridAPIClient {
       },
       protocols: { secure_agg_protocol: 'sec_agg_protocol_id' },
       model_id: 'model_id'
-    });
+    }); */
   }
 
   async getModel(workerId, requestKey, modelId) {
     this.logger.log(
       `[WID: ${workerId}, KEY: ${requestKey}] Requesting model ${modelId}...`
     );
-    const response = await fetch('/data/model_params.pb');
-    return response.arrayBuffer();
+
+    // const response = await fetch('/data/model_params.pb');
+    // return response.arrayBuffer();
+
+    const response = await this._sendHttp(
+      'federated/get-model',
+      {
+        worker_id: workerId,
+        request_key: requestKey,
+        model_id: modelId
+      },
+      'arrayBuffer'
+    );
+    return response;
   }
 
   async getPlan(workerId, requestKey, planId) {
     this.logger.log(
       `[WID: ${workerId}, KEY: ${requestKey}] Requesting plan ${planId}...`
     );
-    const response = await fetch('/data/tp_ops.pb');
-    return response.arrayBuffer();
+
+    // const response = await fetch('/data/tp_ops.pb');
+    // return response.arrayBuffer();
+
+    const response = await this._sendHttp(
+      'federated/get-plan',
+      {
+        worker_id: workerId,
+        request_key: requestKey,
+        plan_id: planId,
+        receive_operations_as: 'list'
+      },
+      'arrayBuffer'
+    );
+
+    return response;
   }
 
   getProtocol(workerId, requestKey, protocolId) {
@@ -59,24 +116,145 @@ export default class GridAPIClient {
     );
   }
 
-  submitReport(workerId, requestKey, data) {
+  async submitReport(workerId, requestKey, diff) {
     this.logger.log(
       `[WID: ${workerId}, KEY: ${requestKey}] Submitting report...`
     );
-    for (let param of data) {
-      param.print();
-    }
-    return Promise.resolve({
-      status: 'success'
+
+    const response = await this._send('federated/report', {
+      worker_id: workerId,
+      request_key: requestKey,
+      diff
     });
+
+    return response;
   }
 
   getConnectionSpeed() {
     // TODO meter speed using /federated/speed-test
     return Promise.resolve({
-      ping: '8ms',
-      download: '46.3mbps',
-      upload: '23.7mbps'
+      ping: '8',
+      download: '46.3',
+      upload: '23.7'
     });
+  }
+
+  async _send(path, data) {
+    const response =
+      this.transport === 'ws'
+        ? await this._sendWs(path, data)
+        : await this._sendHttp(path, data);
+
+    if (response.error) {
+      throw new Error(response.error);
+    }
+
+    return response;
+  }
+
+  async _sendHttp(path, data, type = 'json') {
+    const method = HTTP_PATH_VERB[path] || 'GET';
+    let response;
+
+    if (method === 'GET') {
+      const query = Object.keys(data)
+        .map(k => encodeURIComponent(k) + '=' + encodeURIComponent(data[k]))
+        .join('&');
+      response = await fetch(this.httpUrl + '/' + path + '?' + query, {
+        method: 'GET',
+        mode: 'cors'
+      });
+    } else {
+      response = await fetch(this.httpUrl + '/' + path, {
+        method: 'POST',
+        mode: 'cors',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(data)
+      });
+    }
+
+    if (!response.ok) {
+      throw new Error('Network response was not ok');
+    }
+
+    return response[type]();
+  }
+
+  async _sendWs(type, data) {
+    if (!this.ws) {
+      await this._initWs();
+    }
+
+    const message = { type, data };
+    this.logger.log('Sending WS message', message);
+
+    return new Promise((resolve, reject) => {
+      this.ws.send(JSON.stringify(message));
+
+      const timeoutHandler = setTimeout(() => {
+        this.ws.onmessage = null;
+        reject();
+      }, this.responseTimeout);
+
+      // We expect first message after send to be response.
+      this.ws.onmessage = event => {
+        // reset handlers
+        this.ws.onerror = this._handleWsClose;
+        this.ws.onclose = this._handleWsClose;
+        this.ws.onmessage = null;
+        clearTimeout(timeoutHandler);
+
+        const data = JSON.parse(event.data);
+        this.logger.log('Received message', data);
+        resolve(data);
+      };
+
+      this.ws.onerror = event => {
+        clearTimeout(timeoutHandler);
+        this._handleWsError(event);
+        reject();
+      };
+
+      this.ws.onclose = event => {
+        clearTimeout(timeoutHandler);
+        this._handleWsClose(event);
+        reject();
+      };
+    });
+  }
+
+  async _initWs() {
+    const ws = new WebSocket(this.wsUrl);
+    return new Promise((resolve, reject) => {
+      ws.onopen = () => {
+        // setup handlers
+        ws.onerror = this._handleWsError;
+        ws.onclose = this._handleWsClose;
+        this.ws = ws;
+        resolve();
+      };
+      ws.onerror = event => {
+        // couldn't connect
+        this._handleWsError(event);
+        reject();
+      };
+      ws.onclose = event => {
+        // couldn't connect
+        this._handleWsClose(event);
+        reject();
+      };
+    });
+  }
+
+  _handleWsError(event) {
+    this.logger.log('WS connection error', event);
+    this.ws = null;
+  }
+
+  _handleWsClose(event) {
+    this.logger.log('WS connection closed', event);
+    this.ws = null;
   }
 }

--- a/src/job.js
+++ b/src/job.js
@@ -38,7 +38,7 @@ export default class Job {
 
     // load the model
     const modelData = await this.grid.getModel(
-      this.worker.id,
+      this.worker.worker_id,
       cycleParams.request_key,
       cycleParams.model_id
     );
@@ -51,7 +51,7 @@ export default class Job {
     for (let planName of Object.keys(cycleParams.plans)) {
       const planId = cycleParams.plans[planName];
       const planBinary = await this.grid.getPlan(
-        this.worker.id,
+        this.worker.worker_id,
         cycleParams.request_key,
         planId
       );
@@ -66,7 +66,7 @@ export default class Job {
     for (let protocolName of Object.keys(cycleParams.protocols)) {
       const protocolId = cycleParams.protocols[protocolName];
       const protocolBinary = await this.grid.getProtocol(
-        this.worker.id,
+        this.worker.worker_id,
         cycleParams.request_key,
         protocolId
       );
@@ -84,7 +84,7 @@ export default class Job {
 
     // request cycle
     const cycleParams = await this.grid.requestCycle(
-      this.worker.id,
+      this.worker.worker_id,
       this.modelName,
       this.modelVersion,
       ping,
@@ -95,6 +95,13 @@ export default class Job {
     switch (cycleParams.status) {
       case CYCLE_STATUS_ACCEPTED:
         // load model, plans, protocols, etc.
+        this.logger.log(
+          `Accepted into cycle with params: ${JSON.stringify(
+            cycleParams,
+            null,
+            2
+          )}`
+        );
         await this.initCycle(cycleParams);
 
         this.observer.broadcast('accepted', {
@@ -117,11 +124,16 @@ export default class Job {
     }
   }
 
-  async report(data) {
+  /**
+   * Sends diff to pygrid
+   * @param {ArrayBuffer} diff
+   * @returns {Promise<void>}
+   */
+  async report(diff) {
     await this.grid.submitReport(
-      this.worker.id,
+      this.worker.worker_id,
       this.cycleParams.request_key,
-      data
+      Buffer.from(diff).toString('base64')
     );
   }
 }

--- a/src/protobuf/index.js
+++ b/src/protobuf/index.js
@@ -62,7 +62,32 @@ export const unserialize = (worker, bin, pbType) => {
   return unbufferize(worker, pbObj);
 };
 
+/**
+ * Converts syft class to protobuf-serialized binary
+ * @param worker
+ * @param obj
+ * @returns {ArrayBuffer}
+ */
+export const serialize = (worker, obj) => {
+  const pbObj = obj.bufferize(worker);
+  const pbType = pbObj.constructor;
+  const err = pbType.verify(pbObj);
+  if (err) {
+    throw new Error(err);
+  }
+  const bin = pbType.encode(pbObj).finish();
+  return new Uint8Array(bin).buffer;
+};
+
 export const getPbId = field => {
   // convert int64 to string
   return field[field.id].toString();
+};
+
+export const pbId = value => {
+  if (typeof value === 'number') {
+    return protobuf.syft_proto.types.syft.v1.Id.create({ id_int: value });
+  } else if (typeof value === 'string') {
+    return protobuf.syft_proto.types.syft.v1.Id.create({ id_str: value });
+  }
 };

--- a/src/syft_model.js
+++ b/src/syft_model.js
@@ -1,4 +1,6 @@
-import { unserialize, protobuf } from './protobuf';
+import { unserialize, protobuf, serialize } from './protobuf';
+import { State } from './types/plan';
+import { TorchTensor } from './types/torch';
 
 export default class SyftModel {
   constructor({ worker, modelData }) {
@@ -7,6 +9,26 @@ export default class SyftModel {
       modelData,
       protobuf.syft_proto.execution.v1.State
     );
+    this.worker = worker;
     this.params = state.getTfTensors();
+  }
+
+  async createSerializedDiff(updatedModelParams) {
+    const modelDiff = [];
+    for (let i = 0; i < updatedModelParams.length; i++) {
+      modelDiff.push(this.params[i].sub(updatedModelParams[i]));
+    }
+
+    const tensors = [];
+    for (let param of modelDiff) {
+      tensors.push(await TorchTensor.fromTfTensor(param));
+    }
+    const state = new State([], tensors);
+    const bin = serialize(this.worker, state);
+
+    // free memory
+    tensors.forEach(t => t._tfTensor.dispose());
+
+    return bin;
   }
 }

--- a/src/types/message.js
+++ b/src/types/message.js
@@ -58,7 +58,7 @@ export class Operation extends Message {
       if (tensor instanceof tf.Tensor) {
         return tensor;
       } else if (tensor instanceof TorchTensor) {
-        return tensor._tfTensor;
+        return tensor.toTfTensor();
       } else if (typeof tensor === 'number') {
         return tensor;
       }

--- a/src/types/placeholder.js
+++ b/src/types/placeholder.js
@@ -1,4 +1,4 @@
-import { getPbId } from '../protobuf';
+import { protobuf, getPbId, pbId } from '../protobuf';
 
 export default class Placeholder {
   constructor(id, tags = [], description = null) {
@@ -9,6 +9,16 @@ export default class Placeholder {
 
   static unbufferize(worker, pb) {
     return new Placeholder(getPbId(pb.id), pb.tags || [], pb.description);
+  }
+
+  bufferize(/* worker */) {
+    return protobuf.syft_proto.frameworks.torch.tensors.interpreters.v1.Placeholder.create(
+      {
+        id: pbId(this.id),
+        tags: this.tags,
+        description: this.description
+      }
+    );
   }
 
   getOrderFromTags(prefix) {

--- a/src/types/torch.js
+++ b/src/types/torch.js
@@ -1,4 +1,4 @@
-import { getPbId, unbufferize, protobuf } from '../protobuf';
+import { getPbId, unbufferize, protobuf, pbId } from '../protobuf';
 import * as tf from '@tensorflow/tfjs-core';
 
 export class TorchTensor {
@@ -20,9 +20,13 @@ export class TorchTensor {
     this.gradChain = gradChain;
     this.tags = tags;
     this.description = description;
+  }
 
-    // We need a TensorFlow.js tensor to interact with, but we'll still save all the info above
-    this._tfTensor = tf.tensor(this.contents, this.shape, this.dtype);
+  toTfTensor() {
+    if (!this._tfTensor) {
+      this._tfTensor = tf.tensor(this.contents, this.shape, this.dtype);
+    }
+    return this._tfTensor;
   }
 
   static unbufferize(worker, pb) {
@@ -51,6 +55,39 @@ export class TorchTensor {
       pb.tags,
       pb.description
     );
+  }
+
+  bufferize(/* worker */) {
+    const tensorData = {
+      shape: protobuf.syft_proto.types.torch.v1.Size.create({
+        dims: this.shape
+      }),
+      dtype: this.dtype
+    };
+    tensorData[`contents_${this.dtype}`] = this.contents;
+    const pbTensorData = protobuf.syft_proto.types.torch.v1.TensorData.create(
+      tensorData
+    );
+    return protobuf.syft_proto.types.torch.v1.TorchTensor.create({
+      id: pbId(this.id),
+      serializer:
+        protobuf.syft_proto.types.torch.v1.TorchTensor.Serializer
+          .SERIALIZER_ALL,
+      contents_data: pbTensorData,
+      tags: this.tags,
+      description: this.description
+    });
+  }
+
+  static async fromTfTensor(tensor) {
+    const t = new TorchTensor(
+      tensor.id,
+      await tensor.flatten().array(),
+      tensor.shape,
+      tensor.dtype
+    );
+    t._tfTensor = tensor;
+    return t;
   }
 }
 

--- a/test/protobuf.test.js
+++ b/test/protobuf.test.js
@@ -1,8 +1,11 @@
-import { protobuf, unserialize, getPbId } from '../src/protobuf';
+import { protobuf, unserialize, getPbId, serialize } from '../src/protobuf';
 import { ObjectMessage } from '../src/types/message';
 import Protocol from '../src/types/protocol';
 import { Plan, State } from '../src/types/plan';
 import { PLAN, MODEL, PROTOCOL } from './data/dummy';
+import { TorchTensor } from '../src/types/torch';
+import * as tf from '@tensorflow/tfjs-core';
+import Placeholder from '../src/types/placeholder';
 
 describe('Protobuf', () => {
   test('can unserialize an ObjectMessage', () => {
@@ -29,12 +32,110 @@ describe('Protobuf', () => {
   });
 
   test('can unserialize a State', () => {
-    const plan = unserialize(
+    const state = unserialize(
       null,
       MODEL,
       protobuf.syft_proto.execution.v1.State
     );
-    expect(plan).toBeInstanceOf(State);
+    expect(state).toBeInstanceOf(State);
+  });
+
+  test('can serialize a State', async () => {
+    const placeholders = [
+      new Placeholder('123', ['tag1', 'tag2'], 'placeholder')
+    ];
+    const tensors = [
+      await TorchTensor.fromTfTensor(
+        tf.tensor([
+          [1.1, 2.2],
+          [3.3, 4.4]
+        ])
+      )
+    ];
+    const state = new State(placeholders, tensors);
+    const serialized = serialize(null, state);
+
+    // unserialize back to check
+    const unserState = unserialize(
+      null,
+      serialized,
+      protobuf.syft_proto.execution.v1.State
+    );
+    expect(unserState).toBeInstanceOf(State);
+    expect(unserState.id).toStrictEqual(state.id);
+    expect(unserState.placeholders).toStrictEqual(placeholders);
+    expect(
+      tf
+        .equal(unserState.tensors[0].toTfTensor(), tensors[0].toTfTensor())
+        .all()
+        .dataSync()[0]
+    ).toBe(1);
+  });
+
+  test('can serialize TorchTensor', async () => {
+    const tensor = tf.tensor([
+      [1.1, 2.2],
+      [3.3, 4.4]
+    ]);
+    const torchTensor = await TorchTensor.fromTfTensor(tensor);
+    torchTensor.tags = ['tag1', 'tag2'];
+    torchTensor.description = 'description of tensor';
+
+    // serialize
+    const bin = serialize(null, torchTensor);
+    expect(bin).toBeInstanceOf(ArrayBuffer);
+
+    // check unserialized matches to original
+    const unserTorchTensor = unserialize(
+      null,
+      bin,
+      protobuf.syft_proto.types.torch.v1.TorchTensor
+    );
+    expect(unserTorchTensor.shape).toStrictEqual(torchTensor.shape);
+    expect(unserTorchTensor.dtype).toStrictEqual(torchTensor.dtype);
+    expect(unserTorchTensor.contents).toStrictEqual(torchTensor.contents);
+    // resulting TF tensors are equal
+    expect(
+      tf
+        .equal(unserTorchTensor.toTfTensor(), tensor)
+        .all()
+        .dataSync()[0]
+    ).toBe(1);
+    expect(unserTorchTensor.tags).toStrictEqual(torchTensor.tags);
+    expect(unserTorchTensor.description).toStrictEqual(torchTensor.description);
+  });
+
+  test('can serialize TorchTensor', async () => {
+    const tensor = tf.tensor([
+      [1.1, 2.2],
+      [3.3, 4.4]
+    ]);
+    const torchTensor = await TorchTensor.fromTfTensor(tensor);
+    torchTensor.tags = ['tag1', 'tag2'];
+    torchTensor.description = 'description of tensor';
+
+    // serialize
+    const bin = serialize(null, torchTensor);
+    expect(bin).toBeInstanceOf(ArrayBuffer);
+
+    // check unserialized matches to original
+    const unserTorchTensor = unserialize(
+      null,
+      bin,
+      protobuf.syft_proto.types.torch.v1.TorchTensor
+    );
+    expect(unserTorchTensor.shape).toStrictEqual(torchTensor.shape);
+    expect(unserTorchTensor.dtype).toStrictEqual(torchTensor.dtype);
+    expect(unserTorchTensor.contents).toStrictEqual(torchTensor.contents);
+    // resulting TF tensors are equal
+    expect(
+      tf
+        .equal(unserTorchTensor.toTfTensor(), tensor)
+        .all()
+        .dataSync()[0]
+    ).toBe(1);
+    expect(unserTorchTensor.tags).toStrictEqual(torchTensor.tags);
+    expect(unserTorchTensor.description).toStrictEqual(torchTensor.description);
   });
 
   test('gets id from types.syft.Id', () => {

--- a/test/types/torch.test.js
+++ b/test/types/torch.test.js
@@ -35,7 +35,7 @@ describe('TorchTensor', () => {
     // resulting TF tensors are equal
     expect(
       tf
-        .equal(obj._tfTensor, tfTensor)
+        .equal(obj.toTfTensor(), tfTensor)
         .all()
         .dataSync()[0]
     ).toBe(1);


### PR DESCRIPTION
This PR adds following changes:
 * websocket, http support added in GridAPIClient (selected depending on provided pygrid URL)
 * authenticate, cycle-request, get-model, get-plan, report are doing actual pygrid requests
 * model diff is actually serialized to protobuf and sent to pygrid (report request)

It was tested with following notebooks:
https://github.com/OpenMined/PySyft/pull/3185
And this PyGrid branch: https://github.com/OpenMined/PyGrid/pull/509