### PR TITLE
Fix error when model params are nn.Parameter

### DIFF
--- a/src/types/torch.js
+++ b/src/types/torch.js
@@ -112,4 +112,8 @@ export class TorchParameter {
       unbufferize(worker, pb.grad)
     );
   }
+
+  toTfTensor() {
+    return this.tensor.toTfTensor();
+  }
 }


### PR DESCRIPTION
## Description
MNIST example notebooks host model as serialized list of nn.Parameter's.
syft.js breaks in this case, expecting params to be Tensors.
This change make syft.js more robust and supporting both cases.

## Affected Dependencies
n/a

## How has this been tested?
Executed mnist example.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
