### PR TITLE
Documentation: src/types/message.js

### DIFF
--- a/src/types/message.js
+++ b/src/types/message.js
@@ -1,6 +1,16 @@
 import { unbufferize } from '../protobuf';
 import Logger from '../logger';
+import { protobuf } from 'syft-proto';
 
+/**
+ * Message enables comunicating between PySyft and Syft workers.
+ * Message is the parent class to all other Message types.
+ *
+ * All Message types are currently are currently not in use.
+ *
+ * @property {*} contents - For storing unbufferized message data.
+ * @property {Logger} logger - For logging information.
+ */
 export class Message {
   constructor(contents) {
     if (contents) {
@@ -10,11 +20,23 @@ export class Message {
   }
 }
 
+/**
+ * ObjectMessage is used to send an object as message between PySyft and Syft workers.
+ * @extends Message
+ */
 export class ObjectMessage extends Message {
   constructor(contents) {
     super(contents);
   }
 
+  /**
+   * Unbufferizes and maps data from protobuf object to JS object.
+   *
+   * @static
+   * @param {*} worker - Reserved placeholder for worker-specific arguments when messaging with PySyft.
+   * @param {protobuf.syft_proto.messaging.v1.ObjectMessage} pb - Protobuf object.
+   * @returns {ObjectMessage}
+   */
   static unbufferize(worker, pb) {
     const tensor = unbufferize(worker, pb.tensor);
     return new ObjectMessage(tensor);

--- a/src/types/message.js
+++ b/src/types/message.js
@@ -1,6 +1,5 @@
 import { unbufferize } from '../protobuf';
 import Logger from '../logger';
-import { protobuf } from 'syft-proto';
 
 /**
  * Message enables comunicating between PySyft and Syft workers.


### PR DESCRIPTION
## Description
This PR addresses [Issue #133](https://github.com/OpenMined/syft.js/issues/133) and adds inline documentation to the message types currently implemented (but not used).

@vvmnnnkv Let me know if the documentation to `ObjectMessage`, especially the static method `unbufferize`, is correct or not. Still not sure if `protobuf.syft_proto.messaging.v1.ObjectMessage` is the correct way to document the type :pray: 

## Affected Dependencies
N/A

## How has this been tested?
N/A

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
