### PR TITLE
MNIST example readme updates

### DIFF
--- a/examples/mnist/README.md
+++ b/examples/mnist/README.md
@@ -11,3 +11,14 @@ with [PyGrid](https://github.com/OpenMined/pygrid) to train a plan on local data
 4. And then execute `npm start`
 
 This will launch a web browser running the file `index.js`. Every time you make changes to this file, the server will automatically re-compile your code and refresh the page. No need to start and stop. :)
+
+## Development
+
+This MNIST example is setup to use a remote copy of the syft.js repo (see the `syft.js/examples/mnist/package.json` dependencies param). In order to circumvent this and test changes to syft.js using the MNIST example, we can establish a link to our local copy of syft.js instead:
+
+```
+$ cd <syft.js>/
+$ npm link
+$ cd <syft.js>/examples/mnist
+$ npm link @openmined/syft.js
+```

--- a/examples/mnist/README.md
+++ b/examples/mnist/README.md
@@ -1,12 +1,12 @@
 # syft.js MNIST Example
 
 This is a demonstration of how to use [syft.js](https://github.com/openmined/syft.js)
-with [PyGrid](https://github.com/OpenMined/pygrid) to train a plan on local data in the browser.
+with [PyGrid](https://github.com/OpenMined/PySyft/packages/grid) to train a plan on local data in the browser.
 
 ## Quick Start
 
-1. Install and start [PyGrid](https://github.com/OpenMined/pygrid)
-2. Install [PySyft](https://github.com/OpenMined/PySyft) and [execute the "Part 01 - Create Plan" notebook](https://github.com/OpenMined/PySyft/blob/master/examples/tutorials/model-centric-fl/Part%2001%20-%20Create%20Plan.ipynb) from `examples/tutorials/model-centric-fl` folder to seed the MNIST plan and model into PyGrid.
+1. Install and start [PyGrid](https://github.com/OpenMined/PySyft/packages/grid)
+2. Install [PySyft](https://github.com/OpenMined/PySyft) and [Model Centric Federated Learning - MNIST Example: Create Plan](https://github.com/OpenMined/PySyft/blob/d46768cb53b2ff95264c0c17d2e64f5a125e969e/packages/syft/examples/federated-learning/model-centric/mcfl_create_plan.ipynb) from `packages/syft/examples/federated-learning/model-centric` folder to seed the MNIST plan and model into PyGrid.
 3. Now back in this folder, execute `npm install`
 4. And then execute `npm start`
 
@@ -16,9 +16,9 @@ This will launch a web browser running the file `index.js`. Every time you make 
 
 This MNIST example is setup to use a remote copy of the syft.js repo (see the `syft.js/examples/mnist/package.json` dependencies param). In order to circumvent this and test changes to syft.js using the MNIST example, we can establish a link to our local copy of syft.js instead:
 
-```
-$ cd <syft.js>/
-$ npm link
-$ cd <syft.js>/examples/mnist
-$ npm link @openmined/syft.js
+```console
+cd <syft.js>/
+npm link
+cd <syft.js>/examples/mnist
+npm link @openmined/syft.js
 ```


### PR DESCRIPTION
## Description
- Replaced broken links throughout the `syft.js/examples/mnist/README.md`.
- Added section to explain how devs can point the mnist example to their local copy of syft.js instead of the default remote copy.

## Affected Dependencies
None.

## How has this been tested?
- Links work.
- npm link process has been tested.

## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [X] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [X] My changes are covered by tests
